### PR TITLE
Fix mallocs, proper substring quartet in bin2hexStr

### DIFF
--- a/bin2hexStr.c
+++ b/bin2hexStr.c
@@ -1,19 +1,30 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
 extern char bin2hexChar(char*);
 
 char *bin2hexStr(char *binStr){
-    size_t loops, len = strlen(binStr);
+    int loops, len = (int)strlen(binStr);
     int r = len % 4;
     if(r)
         r = 4 - r;
 
-    char *paddedBin = malloc(len + r + 1);//+1 for null-terminator
+    char *paddedBin = (char *)malloc((len + r + 1)*sizeof(char));//+1 for null-terminator
     memset(paddedBin, '0', r);//add padding to top
     memcpy(paddedBin + r, binStr, len + 1);
     loops = (len + r) / 4;
-    char *hexStr = malloc(loops + 1);//+1 for NUL
-    for(size_t i = 0; i < loops; i++){
-        hexStr[i] = bin2hexChar(paddedBin + i * 4);
+    char *hexStr = (char *)malloc((loops + 1)*sizeof(char));//+1 for NUL
+    int i;
+    // Initialize quartet
+    char *binQuartet = (char *)malloc((4+1)*sizeof(char));
+    for(i = 0; i < loops; i++){
+        // Copy in our 4 bytes
+        memcpy(binQuartet, paddedBin + i * 4, 4);
+        hexStr[i] = bin2hexChar(binQuartet);
     }
+    // Free quartet memory
+    free(binQuartet);
     hexStr[loops] = '\0';
     free(paddedBin);
     return hexStr;


### PR DESCRIPTION
Try this, I only did the `size_t` to `int` switch because gcc on linux was complaining.

```
Testing bin2hexStr ...

Case 1: 11100101 (8 bits):
Expected Result: E5
Actual Result:   E5

Case 2: 000000111110 (12 bits):
Expected Result: 03E
Actual Result:   03E

Case 3: 1000001100110 (13 bits):
Expected Result: 1066
Actual Result:   1066

Case 4: 1000001100110010101 (19 bits):
Expected Result: 41995
Actual Result:   41995

Case 5: 111100111101111110111111 (24 bits):
Expected Result: F3DFBF
Actual Result:   F3DFBF

Case 6: 100001110010011011110110111101101101 (36 bits):
Expected Result: 8726F6F6D
Actual Result:   8726F6F6D

Case 7: 111101010011101000111100111100011010111001 (42 bits):
Expected Result: 3D4E8F3C6B9
Actual Result:   3D4E8F3C6B9

Case 8: 101110101111110000110001110010110011110100110101110110 (54 bits):
Expected Result: 2EBF0C72CF4D76
Actual Result:   2EBF0C72CF4D76
```